### PR TITLE
Ignore unparseable package files

### DIFF
--- a/src/removeNPMAbsolutePaths.js
+++ b/src/removeNPMAbsolutePaths.js
@@ -21,7 +21,14 @@ function removeNPMAbsolutePaths(dir, opts) {
               if (err) return console.log(err);
 
               var writeFile = false;
-              var obj = JSON.parse(data);
+              var obj;
+              try {
+                obj = JSON.parse(data);
+              } catch (e) {
+                // ignore malformed package.json files.
+                return;
+              }
+
               for (var prop in obj) {
                 if (prop[0] === '_') {
                   delete obj[prop];


### PR DESCRIPTION
Was having a problem when using this in conjunction with (locally installed) `electron-packager` file because that repo contains a [malformed package.json](https://github.com/electron-userland/electron-packager/blob/master/test/fixtures/infer-malformed-json/package.json) file for a test case.

This change simply skips any files that can't be parsed instead of throwing the error.