### PR TITLE
off-by-one causing us to tell the user that `folder` has been ignored

### DIFF
--- a/bin/removeNPMAbsolutePaths
+++ b/bin/removeNPMAbsolutePaths
@@ -18,7 +18,7 @@ const opts = {
 
 const ignoredOptions = [];
 
-for (let i = 0; i < args.length; i += 1) {
+for (let i = 1; i < args.length; i += 1) {
   const arg = args[i];
   switch (arg) {
     case '--force':


### PR DESCRIPTION
I made an off by one error that is causing the ignore message to confuse the user, saying it's actually ignoring the path they put in, when it is not.