### PR TITLE
remove dangling comma that breaks older node, but keep linter warning

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "extends": "airbnb-base",
   "rules": {
+    "comma-dangle": 1,
     "strict": 0,
     "prefer-destructuring": 0
   }

--- a/src/removeNPMAbsolutePaths.js
+++ b/src/removeNPMAbsolutePaths.js
@@ -68,7 +68,7 @@ function processFile(filePath, opts) {
     })
     .then(
       r => ({ filePath, rewritten: r.rewritten, success: true }),
-      err => ({ filePath, err, success: false }),
+      err => ({ filePath, err, success: false })
     );
 }
 


### PR DESCRIPTION
Confirmed to work in node v6.  Passes linter and tests.

addresses: https://github.com/juanjoDiaz/removeNPMAbsolutePaths/issues/11